### PR TITLE
Add meson build system support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,29 @@
+project('raytrace', 'cpp', default_options: ['optimization=3'])
+
+raytrace = executable('raytrace', sources: [
+    'lodepng/lodepng.cpp',
+    'raytrace/algebra.cpp',
+    'raytrace/binary.cpp',
+    'raytrace/chessboard.cpp',
+    'raytrace/cuboid.cpp',
+    'raytrace/cylinder.cpp',
+    'raytrace/debug.cpp',
+    'raytrace/dodecahedron.cpp',
+    'raytrace/icosahedron.cpp',
+    'raytrace/main.cpp',
+    'raytrace/optics.cpp',
+    'raytrace/planet.cpp',
+    'raytrace/reorient.cpp',
+    'raytrace/scene.cpp',
+    'raytrace/setcompl.cpp',
+    'raytrace/setisect.cpp',
+    'raytrace/setunion.cpp',
+    'raytrace/solid.cpp',
+    'raytrace/sphere.cpp',
+    'raytrace/spheroid.cpp',
+    'raytrace/thinring.cpp',
+    'raytrace/torus.cpp',
+    'raytrace/triangle.cpp',
+])
+
+test('tests', raytrace, args: ['test'])


### PR DESCRIPTION
As this project didn't had a proper build system for its Unix target I thought it would be a good chance to contribute something and learn in the meanwhile. Adopting a new build system is a controversial decision (just like any new thing) thus am not expecting this to be merged or anything just that I though maybe would be nice to share it with you now that I did it for my personal use.

Meson, nowadays used by many popular low level libraries https://mesonbuild.com/Users.html is one good option for a system that supports creation of Visual Studio project files along its native ninja (the reengineered `make`) support. There is also `cmake` that is more natively supported in Visual Studio but somehow I prefer meson over it.

As this project, published along your book, understandably doesn't have a license thus is fully copyrighted, if you think if is needed for this very small file, I hereby fully donate this small work to you as a token of appreciation for your awesome work :)

To use this, you should first install meson, then execute `meson build` to make meson to generate ninja files in `build` folder, then execute, `ninja -C build`.

The first advantage of this over you current manual build script is the fact it does incremental build which is better in the development process.

Hope you like this and thanks :)